### PR TITLE
Some suggestions for changes to the meta tag and editorial improvements to the document.

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,14 +21,13 @@ The GDD Schema can either be defined in a separate JSON-file, or inline in the H
 **HTML Graphics file, "example.html":**
 
 The `<meta>` tag refers to a JSON-file that contains the GDD Schema definitions.
-The `src=""` path can either be a file path (relative to the html-file's location)
-or a URL.
+The `src=""` attribute can contain either a relative or an absolute URL.
 
 ```html
 <!DOCTYPE html>
 <html lang="en">
   <head>
-    <meta type="gdd-1.0" src="example.json" />
+    <meta name="graphics-template-definition" type="application/json+gdd" src="example.json" />
   </head>
   <body>
     *** Content goes here ***
@@ -64,7 +63,7 @@ The `<meta>` tag can also contain the GDD Schema definitions inline:
 <!DOCTYPE html>
 <html lang="en">
   <head>
-    <meta type="gdd-1.0" >
+    <meta name="graphics-template-definition" type="application/json+gdd">
     <![CDATA[
       {
         "title": "One-Line GFX Template",
@@ -92,7 +91,7 @@ The `<meta>` tag can also contain the GDD Schema definitions inline:
 
 ## General Definition
 
-The GDD is a superset of the [JSON-schema definition](https://json-schema.org/draft/2020-12/json-schema-validation.html#name-a-vocabulary-for-structural), with a few exceptions, see below.
+The GDD is a subset of the [JSON-schema definition](https://json-schema.org/draft/2020-12/json-schema-validation.html#name-a-vocabulary-for-structural), with a few exceptions, see below.
 
 It supports all the basic JSON types (such as strings and numbers) but also extends them with **GDD Types**,
 which can be used by _Graphics client GUIs_ to auto-generate input forms for the data.
@@ -101,7 +100,7 @@ All **GDD Types** are designed to gracefully degrade in case the GUI can't handl
 One example is the `["string", "RRGGBB"]` type which (when supported) can provide a color-picker in the GUI,
 but if not supported will gracefully degrade to a simple text input.
 
-The GUI:s are expected to validate the form-data before submitting it to the GFX Clients.
+The GUIs are expected to validate the form-data before submitting it to the GFX Clients.
 Examples of how to validate can be found here: _---TODO---_
 
 ### Schema
@@ -156,7 +155,7 @@ To reduce the complexity for the GDD GUI implementation however, the valid value
 
 Here follows a list of the basic JSON types supported in GDD.
 
-_All of these types are supported by all GUI:s_
+_All of these types are supported by all GUIs_
 
 ### Boolean
 
@@ -231,9 +230,9 @@ _[JSON-schema definition](https://json-schema.org/draft/2020-12/json-schema-vali
 
 ## GDD Types
 
-Here follows a list of the GDD Types, which provides more advanced functionality in GUI:s.
+Here follows a list of the GDD Types, which provides more advanced functionality in GUIs.
 
-_Not all of these types are supported by all GUI:s. If a type is not supported,
+_Not all of these types are supported by all GUIs. If a type is not supported,
 the GUI will degrade gracefully to the next_
 
 Note: All `type`-properties below can be defined as optional by defining it as `["myType", "null"]`.
@@ -320,11 +319,11 @@ A number presented as a pecentage
 }
 ```
 
-The value is stored as a number, eg 25% -> 0.25
+The value is stored as a number, eg "25%" -> 0.25
 
 ### Duration in milliseconds
 
-A duration presented in a human readable format (like "HH:MM:SS.xxx")
+A duration value, to be presented in a human readable format (like "HH:MM:SS.xxx")
 
 ```json
 {
@@ -333,7 +332,7 @@ A duration presented in a human readable format (like "HH:MM:SS.xxx")
 }
 ```
 
-The value is stored as a number in milliseconds, eg 1m23s -> `83000`
+The value is stored as a number in milliseconds, eg "1m23s" -> `83000`
 
 ## For GUI Developers
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ The `src=""` attribute can contain either a relative or an absolute URL.
 <!DOCTYPE html>
 <html lang="en">
   <head>
-    <meta name="graphics-template-definition" type="application/json+gdd" src="example.json" />
+    <meta name="graphics-data-definition" type="application/json+gdd" src="example.json" />
   </head>
   <body>
     *** Content goes here ***
@@ -63,7 +63,7 @@ The `<meta>` tag can also contain the GDD Schema definitions inline:
 <!DOCTYPE html>
 <html lang="en">
   <head>
-    <meta name="graphics-template-definition" type="application/json+gdd">
+    <meta name="graphics-data-definition" type="application/json+gdd">
     <![CDATA[
       {
         "title": "One-Line GFX Template",


### PR DESCRIPTION
I'd like to make a couple of suggestions for improvements in the spec.

1. The use of element content for a meta tag is very non-standard, but I don't think it's a deal-breaker. However, I believe we should follow the convention of requiring either a `name` or a `http-equiv` attribute on a `meta` tag. If we don't, we are inviting problems for anyone doing any DOM traversal on the `head` tag who is not expecting both `name` and `http-equiv` to be undefined. Because of that, I propose providing a `name` attribute of value `graphics-data-definition`. While this is quite verbose, it's not much more verbose than some Apple-specific meta tags, for example [(1)](https://developer.apple.com/library/archive/documentation/AppleApplications/Reference/SafariHTMLRef/Articles/MetaTags.html).
2. I think we should make a commitment that GDD will always be backwards- and forwards-compatible. If that is so, there is little point in providing a version identifier in the "type". If a need arises for a breaking change, the type could be simply changed to be "GDD2". Because of that, I suggest using a more standard approach of using a MIME-type for type, and using an application specific notation of `application/json+gdd` which will provide both information about the used transportation format (JSON) and the semantics scheme (GDD).
3. I've also included some editorial improvements, such as saying that GDD is a "sub-set" of JSON Schema, rather than a "super-set", since JSON Schema is a more generic specification and GDD is just sub-setting it, limiting it and providing some additional extensions (which are themselves also a sub-set of the included application-specific extension system built into JSON Schema). I also propose clarifying that the `src` attribute either contains an absolute or relative URL, instead of saying "file path", since the meaning of "file path" can be vague in terms of notation.