### PR TITLE
Add playoutOptions to the Schema.

### DIFF
--- a/README.md
+++ b/README.md
@@ -452,25 +452,11 @@ _Note: All of the properties inside of `gddPlayoutOptions` are optional._
 
     /** This object contains specific options for the various playout server types (CasparCG, Viz, vMix etc..) */
     "playout" {
-      "casparcg": {
-        /** The default server to play on (an IP-address or a hostname). */
-        "serverHost": string
-        /** The default server to play on. */
-        "serverPort": number
-
-        /** The default / suggested channel to play on */
-        "channel": number
-        /** The default / suggested layer to play on */
-        "layer": number
-
-      },
-      "vMix": {
-        // Todo
-      },
-      "viz": {
-        // Todo
+      "**type-of-device**": {
+       // See Appendix for the device-specific options
       }
     }
   }
 }
 ```
+Details for the device-specific options are described in [Appendix: Playout Options](/doc/appendix/playout-options.md)

--- a/README.md
+++ b/README.md
@@ -425,12 +425,12 @@ _Note: All of the properties inside of `gddPlayoutOptions` are optional._
     "client": {
       /**
        * The suggested duration of the template (in milliseconds)
-       * -1 means that it is manually taken out
-       * undefined should be treated as -1
+       * null means that it is manually taken out
+       * undefined should be treated as null
        * (This is ignored if steps=0)
-       * Defaults to -1
+       * Defaults to null
        */
-      "duration": number,
+      "duration": number | null
 
       /**
        * Number of steps in the template

--- a/README.md
+++ b/README.md
@@ -447,7 +447,7 @@ _Note: All of the properties inside of `gddPlayoutOptions` are optional._
        * This is mostly used for the older CasparCG flash-based xml data format.
        * Defaults to "json"
        */
-      "dataformat": "xml" | "json"
+      "dataformat": "json" | "caspar-xml"
     },
 
     /** This object contains specific options for the various playout server types (CasparCG, Viz, vMix etc..) */
@@ -459,4 +459,6 @@ _Note: All of the properties inside of `gddPlayoutOptions` are optional._
   }
 }
 ```
+Details on the CasparCG XML format are described in [Appendix: CasparCG XML](/doc/appendix/casparcg-xml.md)
+
 Details for the device-specific options are described in [Appendix: Playout Options](/doc/appendix/playout-options.md)

--- a/README.md
+++ b/README.md
@@ -130,6 +130,9 @@ Examples of how to validate can be found here: _---TODO---_
     "myProperty": {}
   },
   "required": [] // [optional]
+  "gddPlayoutOptions": { // [optional]
+    // Contents described under "Playout options" below
+  }
 }
 ```
 
@@ -392,9 +395,82 @@ function determineComponent(prop) {
   if (basicType === "integer") return componentInteger(prop);
   if (basicType === "array") return componentArray(prop);
   if (basicType === "object") return componentObject(prop);
+  if (basicType === "null") return null
 
   return null;
 }
 ```
 
 Please have a look at a [reference GUI implementation here](/blob/main/reference-gui/src/gdd-gui.jsx), and [its live demo here.](https://superflytv.github.io/GraphicsDataDefinition/reference-gui/dist/)
+
+
+## Playout Options
+
+In the Schema, there is an option to add the `gddPlayoutOptions` object with various properties therein.
+These properties can be read by the playout client in order to modify how it'll display / use / play the template.
+
+_Note: All of the properties inside of `gddPlayoutOptions` are optional._
+
+```typescript
+{
+  "title": "My GFX Template",
+  "type": "object",
+  "properties": {
+    "myProperty": {
+      // ...
+    }
+  },
+  "gddPlayoutOptions": {
+    /** This object contains options that aren't tied to a specific playout server */
+    "client": {
+      /**
+       * The suggested duration of the template (in milliseconds)
+       * -1 means that it is manually taken out
+       * undefined should be treated as -1
+       * (This is ignored if steps=0)
+       * Defaults to -1
+       */
+      "duration": number,
+
+      /**
+       * Number of steps in the template
+       * 1 means that there are no steps (ie there's only "the default step").
+       * 2 or more means that it can be "stepped" (ie 2 means it can be stepped once).
+       * -1 means "infinite" number of steps.
+       * 0 means that the template is "volatile" / "fire and forget" (template really has no duration, like a bumper).
+       * Defaults to 1
+      */
+      "steps": number,
+
+      /**
+       * How the data should be formatted.
+       * This is mostly used for the older CasparCG flash-based xml data format.
+       * Defaults to "json"
+       */
+      "dataformat": "xml" | "json"
+    },
+
+    /** This object contains specific options for the various playout server types (CasparCG, Viz, vMix etc..) */
+    "playout" {
+      "casparcg": {
+        /** The default server to play on (an IP-address or a hostname). */
+        "serverHost": string
+        /** The default server to play on. */
+        "serverPort": number
+
+        /** The default / suggested channel to play on */
+        "channel": number
+        /** The default / suggested layer to play on */
+        "layer": number
+
+      },
+      "vMix": {
+        // Todo
+      },
+      "viz": {
+        // Todo
+      }
+    }
+  }
+}
+```

--- a/doc/appendix/casparcg-xml.md
+++ b/doc/appendix/casparcg-xml.md
@@ -1,0 +1,65 @@
+# CasparCG XML data format
+
+_Note: The information on this page is for reference only, it might not work with your particular CasparCG Flash-template._
+
+## Background
+
+In the old days, CasparCG supported Flash-based templates that used a XML-based schema for data interchange.
+
+For backwards-compatiblity, the option `client.gddPlayoutOptions.dataformat: "json" | "caspar-xml"` is provided as a way for playout clients to support the old Flash-based templates.
+
+
+## Data conversion
+
+Here is an example of the normal JSON-data and its XML equivalent:
+
+**JSON data:**
+```typescript
+{
+  "f0": "This is the first line",
+  "f1": "second line"
+}
+```
+
+**CasparCG XML data:**
+```xml
+<templateData>
+    <componentData id="f0"><data id="text" value="This is the first line" /></componentData>
+    <componentData id="f1"><data id="text" value="second line" /></componentData>
+</templateData>
+```
+
+## Example implementation
+
+Here is a bare-bones example implementation for the XML conversion, in javascript.
+
+```javascript
+function parametersToCasparXML(json, basePath) {
+	basePath = basePath || ''
+    let xml = ''
+	for (const [key, value] of Object.entries(json)) {
+        const path = (basePath ? basePath + '.' : '') + key
+
+        if (typeof value === 'object') {
+            xml += parametersToCasparXML(value, path)
+        } else {
+            xml += `<componentData id="${path}"><data id="text" value="${escapeStringForXML(value)}" /></componentData>\n`
+        }
+	}
+
+    if (!basePath) {
+        return `<templateData>\n${xml}</templateData>`
+    } else {
+        return xml
+    }
+}
+function escapeStringForXML(unsafe) {
+	if (!unsafe) return ''
+	return `${unsafe}`
+		.replace(/&/g, '&amp;')
+		.replace(/</g, '&lt;')
+		.replace(/>/g, '&gt;')
+		.replace(/"/g, '&quot;')
+		.replace(/'/g, '&apos;')
+}
+```

--- a/doc/appendix/playout-options.md
+++ b/doc/appendix/playout-options.md
@@ -1,0 +1,54 @@
+# Playout Options
+
+In the Schema, there is an option to add the `gddPlayoutOptions` object with various properties therein.
+These properties can be read by a playout client in order to modify how it'll display / use / play the template.
+
+_Note: All of the properties inside of `gddPlayoutOptions` are optional._
+
+```typescript
+{
+  "title": "My GFX Template",
+  "type": "object",
+  "properties": {
+    "myProperty": {
+      // ...
+    }
+  },
+  "gddPlayoutOptions": {
+    /** This object contains specific options for the various playout server types (CasparCG, Viz, vMix etc..) */
+    "playout" {
+      // The contents of this object are described in the sections below
+    }
+  }
+}
+```
+
+## CasparCG
+
+
+```typescript
+{
+  "gddPlayoutOptions": {
+    "playout" {
+      "casparcg": {
+        /** The default server to play on (an IP-address or a hostname). */
+        "serverHost"?: string
+        /** The default server to play on. */
+        "serverPort"?: number
+
+        /** The default / suggested channel to play on */
+        "channel"?: number
+        /** The default / suggested layer to play on */
+        "layer"?: number
+
+      },
+    }
+  }
+}
+```
+
+
+## vMix
+
+_This sections is yet to be written_
+


### PR DESCRIPTION
This PR adds the "Playout options" to the schema, out intention with this is that these properties can be used by the playout-client to modify how it'll display / use / play the template.


Co-authored by Ivan Maretic <ivan.maretic@live.com> and Tuomo Kulomaa <tuomo@smartpx.fi>