### PR TITLE
feat: add authorName and authorEmail

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,8 @@ Examples of how to validate can be found here: _---TODO---_
   "$schema": "https://superflytv.github.io/GraphicsDataDefinition/gdd-meta-schema/v1/schema.json", // [optional] Reference to the JSON-schema
   "title": "", // [optional] string, a short name of the GFX-template. Used for informational purposes only.
   "description": "", // [optional] string, a description GFX-template. Used for informational purposes only.
+  "authorName": "", // [optional] string, name of the author.
+  "authorEmail": "", // [optional] string, email to the author.
   "type": "object", // MUST be "object"
   "properties": {
     // MUST be an object

--- a/gdd-meta-schema/v1/schema.json
+++ b/gdd-meta-schema/v1/schema.json
@@ -23,6 +23,15 @@
     "description": {
       "type": "string"
     },
+    "authorName": {
+      "type": "string",
+      "description": "Name of the author"
+    },
+    "authorEmail": {
+      "type": "string",
+      "description": "Email to the author",
+      "format": "email"
+    },
     "properties": {
       "type": "object",
       "patternProperties": {

--- a/lib/unit-tests/__tests__/basic.test.ts
+++ b/lib/unit-tests/__tests__/basic.test.ts
@@ -76,9 +76,26 @@ describe('Schema - Basic types', () => {
 			validateSchema({
 				type: 'object',
 				properties: {},
+				authorName: 123 // bad type
+			})
+		).toMatch(/not.*string/)
+		expect(
+			validateSchema({
+				type: 'object',
+				properties: {},
+				authorEmail: "not-an-email" // bad format
+			})
+		).toMatch(/does not conform.*email.*format/)
+
+		expect(
+			validateSchema({
+				type: 'object',
+				properties: {},
 				title: 'A title',
 				description: 'a description',
 				$schema: 'https://superflytv.github.io/GraphicsDataDefinition/gdd-meta-schema/v1/schema.json',
+				authorName: 'author',
+				authorEmail: 'test@test.com',
 				gddPlayoutOptions: {},
 			})
 		).toBe(null)

--- a/lib/unit-tests/__tests__/basic.test.ts
+++ b/lib/unit-tests/__tests__/basic.test.ts
@@ -76,14 +76,14 @@ describe('Schema - Basic types', () => {
 			validateSchema({
 				type: 'object',
 				properties: {},
-				authorName: 123 // bad type
+				authorName: 123, // bad type
 			})
 		).toMatch(/not.*string/)
 		expect(
 			validateSchema({
 				type: 'object',
 				properties: {},
-				authorEmail: "not-an-email" // bad format
+				authorEmail: 'not-an-email', // bad format
 			})
 		).toMatch(/does not conform.*email.*format/)
 		expect(


### PR DESCRIPTION
This PR adds the fields `authorName` and `authorEmail`.

This was initially suggested by @didikunz in [this thread on casparcgforum.com](https://casparcgforum.org/t/metadata-for-templates/5064/14).