### PR TITLE
suggestion: resolutions

### DIFF
--- a/README.md
+++ b/README.md
@@ -502,6 +502,7 @@ _Note: All of the properties inside of `gddPlayoutOptions` are optional._
       /**
        * This property contains an array of the supported resolutions of the GFX Template.
        * The array must contain at least one resolution.
+       * This can be used by the client to determine whether a template is compatible with the current renderer or not.
        * Examples:
        * * A template which only supports a fixed resolution and framerate:
        *   "resolutions": [{ "width": 1280, "height": 720, "framerate": 50 }]

--- a/README.md
+++ b/README.md
@@ -498,7 +498,7 @@ _Note: All of the properties inside of `gddPlayoutOptions` are optional._
     },
 
     /** This object contains specific options for the various playout server types (CasparCG, Viz, vMix etc..) */
-    "playout" {
+    "playout": {
       "**type-of-device**": {
        // See Appendix for the device-specific options
       }

--- a/README.md
+++ b/README.md
@@ -497,6 +497,40 @@ _Note: All of the properties inside of `gddPlayoutOptions` are optional._
       "dataformat": "json" | "casparcg-xml"
     },
 
+    /** This object contains generic options related to the rendering of the GFX template */
+    "render": {
+      /**
+       * This property contains an array of the supported resolutions of the GFX Template.
+       * The array must contain at least one resolution.
+       * Examples:
+       * * A template which only supports a fixed resolution and framerate:
+       *   "resolutions": [{ "width": 1280, "height": 720, "framerate": 50 }]
+       * * A template which supports 720p50 and 1080p50:
+       *   "resolutions": [{ "width": 1280, "height": 720, "framerate": 50 }, { "width": 1920, "height": 1080, "framerate": 50 }]
+       * * A template which supports any resolution above 500x500 (and any framerate):
+       *   "resolutions": [{ "width": { min: 500 }, "height": { min: 500 } }]
+       *
+       */
+      "resolutions": [
+        {
+          "width": {
+            "min": number
+            "max": number
+          } | number,
+          "height": {
+            "min": number
+            "max": number
+          } | number,
+          "framerate": {
+            "min": number
+            "max": number
+          } | number,
+        }
+      ]
+
+
+    },
+
     /** This object contains specific options for the various playout server types (CasparCG, Viz, vMix etc..) */
     "playout": {
       "**type-of-device**": {

--- a/gdd-meta-schema/v1/lib/playout-options.json
+++ b/gdd-meta-schema/v1/lib/playout-options.json
@@ -21,6 +21,40 @@
         }
       }
     },
+    "render": {
+      "type": "object",
+      "properties": {
+        "resolutions": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "object",
+            "patternProperties": {
+              "width|height|framerate": {
+                "type": ["number", "object"],
+                "allOf": [
+                  {
+                    "if": {
+                      "type": "object"
+                    },
+                    "then": {
+                      "properties": {
+                        "min": {
+                          "type": "number"
+                        },
+                        "max": {
+                          "type": "number"
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        }
+      }
+    },
     "playout": {
       "type": "object"
     }

--- a/lib/unit-tests/__tests__/lib/validator.ts
+++ b/lib/unit-tests/__tests__/lib/validator.ts
@@ -113,8 +113,6 @@ async function getJSON(filePath: string): Promise<any> {
 			if (e.message) e.message = e.message + ' ' + filePath
 			throw e
 		}
-
-
 	} else {
 		return null
 	}

--- a/lib/unit-tests/__tests__/lib/validator.ts
+++ b/lib/unit-tests/__tests__/lib/validator.ts
@@ -105,11 +105,16 @@ async function getJSON(filePath: string): Promise<any> {
 
 	if (await fileExists(filePath)) {
 		const read = await fs.promises.readFile(filePath, 'utf-8')
-		const content = JSON.parse(read)
+		try {
+			const content = JSON.parse(read)
+			cache.set(filePath, content)
+			return content
+		} catch (e: any) {
+			if (e.message) e.message = e.message + ' ' + filePath
+			throw e
+		}
 
-		cache.set(filePath, content)
 
-		return content
 	} else {
 		return null
 	}

--- a/lib/unit-tests/__tests__/playout-options.test.ts
+++ b/lib/unit-tests/__tests__/playout-options.test.ts
@@ -125,7 +125,7 @@ test('gddPlayoutOptions.render', async () => {
 			properties: {},
 			gddPlayoutOptions: {
 				render: {
-					resolutions: [] // empty is not allowed
+					resolutions: [], // empty is not allowed
 				},
 			},
 		})
@@ -136,7 +136,7 @@ test('gddPlayoutOptions.render', async () => {
 			properties: {},
 			gddPlayoutOptions: {
 				render: {
-					resolutions: [ { width: 123 } ]
+					resolutions: [{ width: 123 }],
 				},
 			},
 		})
@@ -147,7 +147,7 @@ test('gddPlayoutOptions.render', async () => {
 			properties: {},
 			gddPlayoutOptions: {
 				render: {
-					resolutions: [ { width: "123" } ] // bad type
+					resolutions: [{ width: '123' }], // bad type
 				},
 			},
 		})
@@ -158,7 +158,7 @@ test('gddPlayoutOptions.render', async () => {
 			properties: {},
 			gddPlayoutOptions: {
 				render: {
-					resolutions: [ { width: { min: 100, max: 9999 } } ]
+					resolutions: [{ width: { min: 100, max: 9999 } }],
 				},
 			},
 		})
@@ -169,7 +169,7 @@ test('gddPlayoutOptions.render', async () => {
 			properties: {},
 			gddPlayoutOptions: {
 				render: {
-					resolutions: [ { width: { max: "two" } } ] // bad type
+					resolutions: [{ width: { max: 'two' } }], // bad type
 				},
 			},
 		})
@@ -180,7 +180,7 @@ test('gddPlayoutOptions.render', async () => {
 			properties: {},
 			gddPlayoutOptions: {
 				render: {
-					resolutions: [ { width: { max: 9000 }, height: 500, framerate: 50 } ]
+					resolutions: [{ width: { max: 9000 }, height: 500, framerate: 50 }],
 				},
 			},
 		})
@@ -191,7 +191,7 @@ test('gddPlayoutOptions.render', async () => {
 			properties: {},
 			gddPlayoutOptions: {
 				render: {
-					resolutions: [ { width: { max: 9000 }, height: 500, framerate: "50" } ] // bad type
+					resolutions: [{ width: { max: 9000 }, height: 500, framerate: '50' }], // bad type
 				},
 			},
 		})

--- a/lib/unit-tests/__tests__/playout-options.test.ts
+++ b/lib/unit-tests/__tests__/playout-options.test.ts
@@ -1,6 +1,6 @@
 import { setupValidator } from './lib/validator'
 
-test('playout-options', async () => {
+test('gddPlayoutOptions.client', async () => {
 	const validateSchema = await setupValidator()
 
 	// Minimal object:
@@ -106,7 +106,7 @@ test('playout-options', async () => {
 		})
 	).toMatch(/is not.*json/)
 })
-test('playout', async () => {
+test('gddPlayoutOptions.playout', async () => {
 	const validateSchema = await setupValidator()
 
 	// Minimal object:

--- a/lib/unit-tests/__tests__/playout-options.test.ts
+++ b/lib/unit-tests/__tests__/playout-options.test.ts
@@ -106,6 +106,97 @@ test('gddPlayoutOptions.client', async () => {
 		})
 	).toMatch(/is not.*json/)
 })
+test('gddPlayoutOptions.render', async () => {
+	const validateSchema = await setupValidator()
+
+	// Minimal object:
+	expect(
+		validateSchema({
+			type: 'object',
+			properties: {},
+			gddPlayoutOptions: {
+				render: {},
+			},
+		})
+	).toBe(null)
+	expect(
+		validateSchema({
+			type: 'object',
+			properties: {},
+			gddPlayoutOptions: {
+				render: {
+					resolutions: [] // empty is not allowed
+				},
+			},
+		})
+	).toMatch(/min.*length/)
+	expect(
+		validateSchema({
+			type: 'object',
+			properties: {},
+			gddPlayoutOptions: {
+				render: {
+					resolutions: [ { width: 123 } ]
+				},
+			},
+		})
+	).toBe(null)
+	expect(
+		validateSchema({
+			type: 'object',
+			properties: {},
+			gddPlayoutOptions: {
+				render: {
+					resolutions: [ { width: "123" } ] // bad type
+				},
+			},
+		})
+	).toMatch(/is not.*number,object/)
+	expect(
+		validateSchema({
+			type: 'object',
+			properties: {},
+			gddPlayoutOptions: {
+				render: {
+					resolutions: [ { width: { min: 100, max: 9999 } } ]
+				},
+			},
+		})
+	).toBe(null)
+	expect(
+		validateSchema({
+			type: 'object',
+			properties: {},
+			gddPlayoutOptions: {
+				render: {
+					resolutions: [ { width: { max: "two" } } ] // bad type
+				},
+			},
+		})
+	).toMatch(/is not.*number/)
+	expect(
+		validateSchema({
+			type: 'object',
+			properties: {},
+			gddPlayoutOptions: {
+				render: {
+					resolutions: [ { width: { max: 9000 }, height: 500, framerate: 50 } ]
+				},
+			},
+		})
+	).toBe(null)
+	expect(
+		validateSchema({
+			type: 'object',
+			properties: {},
+			gddPlayoutOptions: {
+				render: {
+					resolutions: [ { width: { max: 9000 }, height: 500, framerate: "50" } ] // bad type
+				},
+			},
+		})
+	).toMatch(/is not.*number/)
+})
 test('gddPlayoutOptions.playout', async () => {
 	const validateSchema = await setupValidator()
 


### PR DESCRIPTION
This PR adds the `gddPlayoutOptions.render.resolutions` property.

The initial idea came from [this thread on casparcgforum.com](https://casparcgforum.org/t/metadata-for-templates/5064/14).

The intention with this property is that it can be used by a playout client to determine whether a template is compatible with the current renderer or not. Incompatible templates could either be hidden in lists or marked with a warning.

**Motivation of data structure**

There are many different types of ways a template can support various resolutions.
We need to be able to support templates that support:
* any resolution and any framerate.
* any resolution but only a certain framerate
* a couple of certain resolutions (like 720p50 + 1080p50)
* portrait and landscape

This data structure should make it easy to define the simplest situations, as well as the more intricate ones.
Examples:
```typescript

// Support only 720p50:
"resolutions": [{ "width": 1280, "height": 720, "framerate": 50 }]

// Support only 720p50 and 1080p50:
"resolutions": [
  { "width": 1280, "height": 720, "framerate": 50 },
  { "width": 1920, "height": 1080, "framerate": 50 }
]

// Support 720p50 in portrait and landscape
"resolutions": [
  { "width": 1280, "height": 720, "framerate": 50 }
  { "width": 720, "height": 1280, "framerate": 50 }
]

// Support any resolution above 500x500 (and any framerate):
"resolutions": [{ "width": { min: 500 }, "height": { min: 500 } }]


```


